### PR TITLE
Fix issue, with request teardown during test teardown instead of test run.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,9 @@ Upcomming release
 -----------------
 
 - Add changelog to documentation.
+- Fix issue, when request teardown happened during test teardown instead of
+  test run. As a result "keeping context around" feature has gone, as well
+  as ``request_ctx`` fixture.
 
 0.10.0 (compared to 0.9.0)
 --------------------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -5,14 +5,6 @@ Feature reference
 
 Extension provides some sugar for your tests, such as:
 
-* Access to context bound objects (``url_for``, ``request``, ``session``)
-  without context managers:
-
-  .. code:: python
-
-    def test_app(client):
-        assert client.get(url_for('myview')).status_code == 200
-
 * Easy access to ``JSON`` data in response:
 
   .. code:: python
@@ -81,12 +73,6 @@ testing. More information on fixtures and their usage is available in the
 
 An instance of ``app.test_client``. Typically refers to
 `flask.Flask.test_client`_.
-
-.. hint::
-
-    During tests execution the request context has been pushed, e.g.
-    ``url_for``, ``session`` and other context bound objects are available
-    without context managers.
 
 Example:
 
@@ -172,26 +158,6 @@ example, in your project's ``pytest.ini`` file)::
             res = urlopen(url_for('test_endpoint', _external=True))
             assert res.code == 200
             assert b'got it' in res.read()
-
-
-``request_ctx`` - request context
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The request context which contains all request relevant information.
-
-.. hint::
-
-    The request context has been pushed implicitly any time the ``app``
-    fixture is applied and is kept around during test execution, so it's easy
-    to introspect the data:
-
-    .. code:: python
-
-        from flask import request, url_for
-
-        def test_request_headers(client):
-            res = client.get(url_for('ping'), headers=[('X-Something', '42')])
-            assert request.headers['X-Something'] == '42'
 
 
 Content negotiation

--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -10,16 +10,13 @@ try:
 except ImportError:
     from urllib.request import urlopen
 
-from flask import _request_ctx_stack
 
-
-@pytest.yield_fixture
+@pytest.fixture
 def client(app):
     """A Flask test client. An instance of :class:`flask.testing.TestClient`
     by default.
     """
-    with app.test_client() as client:
-        yield client
+    return app.test_client()
 
 
 @pytest.fixture
@@ -134,14 +131,6 @@ def live_server(request, app, monkeypatch):
 def config(app):
     """An application config."""
     return app.config
-
-
-@pytest.fixture
-def request_ctx(app):
-    """The request context which contains all request relevant information,
-    e.g. `session`, `g`, `flashes`, etc.
-    """
-    return _request_ctx_stack.top
 
 
 @pytest.fixture(params=['application/json', 'text/html'])

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -13,7 +13,7 @@ from werkzeug import cached_property
 
 from .fixtures import (
     client, config, accept_json, accept_jsonp, accept_any, accept_mimetype,
-    client_class, live_server, request_ctx
+    client_class, live_server
 )
 
 
@@ -62,35 +62,6 @@ def _monkeypatch_response_class(request, monkeypatch):
     monkeypatch.setattr(app, 'response_class',
                         _make_test_response_class(app.response_class))
 
-
-@pytest.fixture(autouse=True)
-def _push_request_context(request):
-    """During tests execution request context has been pushed, e.g. `url_for`,
-    `session`, etc. can be used in tests as is::
-
-        def test_app(app, client):
-            assert client.get(url_for('myview')).status_code == 200
-
-    """
-    if 'app' not in request.fixturenames:
-        return
-
-    app = request.getfuncargvalue('app')
-
-    # Get application bound to the live server if ``live_server`` fixture
-    # is applyed. Live server application has an explicit ``SERVER_NAME``,
-    # so ``url_for`` function generates a complete URL for endpoint which
-    # includes application port as well.
-    if 'live_server' in request.fixturenames:
-        app = request.getfuncargvalue('live_server').app
-
-    ctx = app.test_request_context()
-    ctx.push()
-
-    def teardown():
-        ctx.pop()
-
-    request.addfinalizer(teardown)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,16 +2,16 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from flask import request, url_for
+from flask import request, url_for, Flask
 
 
 class TestFixtures:
-
     def test_config_access(self, config):
         assert config['SECRET_KEY'] == '42'
 
-    def test_client(self, client):
-        assert client.get(url_for('ping')).status == '200 OK'
+    def test_client(self, app, client):
+        with app.test_request_context():
+            assert client.get(url_for('ping')).status == '200 OK'
 
     def test_accept_json(self, accept_json):
         assert accept_json == [('Accept', 'application/json')]
@@ -19,19 +19,37 @@ class TestFixtures:
     def test_accept_jsonp(self, accept_jsonp):
         assert accept_jsonp == [('Accept', 'application/json-p')]
 
-    def test_request_ctx(self, app, request_ctx):
-        assert request_ctx.app is app
 
-    def test_request_ctx_is_kept_around(self, client):
-        res = client.get(url_for('index'), headers=[('X-Something', '42')])
-        assert request.headers['X-Something'] == '42'
+class TestClientTeardown:
+    @staticmethod
+    @pytest.fixture
+    def app():
+        """App, that registers if request teardown was happened."""
+        app = Flask(__name__)
+        app.route('/spam')(lambda: 'eggs')
+
+        app.teardown_happened = False
+
+        @app.teardown_request
+        def teardown(*_, **__):
+            app.teardown_happened = True
+
+        return app
+
+    def test_client_teardown(self, app, client):
+        """Request teardown happens before test teardown."""
+        # app, client = app_and_client
+
+        assert client.get('/spam').status_code == 200
+        assert app.teardown_happened
 
 
 class TestJSONResponse:
 
-    def test_json_response(self, client, accept_json):
-        res = client.get(url_for('ping'), headers=accept_json)
-        assert res.json == {'ping': 'pong'}
+    def test_json_response(self, app, client, accept_json):
+        with app.test_request_context():
+            res = client.get(url_for('ping'), headers=accept_json)
+            assert res.json == {'ping': 'pong'}
 
     def test_dont_rewrite_existing_implementation(self, app, accept_json):
         class MyResponse(app.response_class):
@@ -42,14 +60,15 @@ class TestJSONResponse:
 
         app.response_class = MyResponse
         client = app.test_client()
-
-        res = client.get(url_for('ping'), headers=accept_json)
+        with app.test_request_context():
+            res = client.get(url_for('ping'), headers=accept_json)
         assert res.json == 42
 
 
 @pytest.mark.usefixtures('client_class')
 class TestClientClass:
 
-    def test_client_attribute(self):
+    def test_client_attribute(self, app):
         assert hasattr(self, 'client')
-        assert self.client.get(url_for('ping')).json == {'ping': 'pong'}
+        with app.test_request_context():
+            assert self.client.get(url_for('ping')).json == {'ping': 'pong'}

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -24,8 +24,10 @@ class TestLiveServer:
         assert res.code == 200
         assert b'pong' in res.read()
 
-    def test_url_for(self, live_server):
-        assert url_for('ping', _external=True) == 'http://localhost:%s/ping' % live_server.port
+    def test_url_for(self, app, live_server):
+        expected_url = 'http://localhost:%s/ping' % live_server.port
+        with app.test_request_context():
+            assert url_for('ping', _external=True) == expected_url
 
     def test_set_application_server_name(self, live_server):
         assert live_server.app.config['SERVER_NAME'] == 'localhost:%d' % live_server.port
@@ -68,14 +70,15 @@ class TestLiveServer:
 
             from flask import url_for
 
-            def test_a(live_server):
+            def test_a(live_server, app):
                 @live_server.app.route('/new-endpoint')
                 def new_endpoint():
                     return 'got it', 200
 
                 live_server.start()
 
-                res = urlopen(url_for('new_endpoint', _external=True))
+                with app.test_request_context():
+                    res = urlopen(url_for('new_endpoint', _external=True))
                 assert res.code == 200
                 assert b'got it' in res.read()
         ''')


### PR DESCRIPTION
I had a setup, where each test was wrapped in transaction and each in it's turn was wrapped in sub-transaction. Both transaction was rolled back in the end, request's in `app.teardown_request` and test's in PyTest test teardown. And the issue was, that  test transaction was rolled back before request transaction, so sub-transaction was rolled back after top-level one. 

But there is a problem - this change breaks keeping context around feature.
