### PR TITLE
prevent intermittent broken_pipe errors with threaded=True

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -57,7 +57,7 @@ class LiveServer(object):
     def start(self):
         """Start application in a separate process."""
         def worker(app, port):
-            app.run(port=port, use_reloader=False)
+            app.run(port=port, use_reloader=False, threaded=True)
         self._process = multiprocessing.Process(
             target=worker,
             args=(self.app, self.port)


### PR DESCRIPTION
Running my tests I am getting frequent but intermittent broken pipe errors when accessing various app endpoints. I was able to solve this locally by adding `threaded=True` to `app.run` invocation [here](https://github.com/pytest-dev/pytest-flask/blob/5048d0cc7bd4301cf57c93ab6889819f490e9521/pytest_flask/fixtures.py#L60)