### PR TITLE
Run away from getfuncargvalue deprecation.

### DIFF
--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -15,6 +15,7 @@ from .fixtures import (
     client, config, accept_json, accept_jsonp, accept_any, accept_mimetype,
     client_class, live_server, request_ctx
 )
+from .pytest_compat import getfixturevalue
 
 
 class JSONResponse(object):
@@ -58,7 +59,7 @@ def _monkeypatch_response_class(request, monkeypatch):
     if 'app' not in request.fixturenames:
         return
 
-    app = request.getfuncargvalue('app')
+    app = getfixturevalue(request, 'app')
     monkeypatch.setattr(app, 'response_class',
                         _make_test_response_class(app.response_class))
 
@@ -75,14 +76,14 @@ def _push_request_context(request):
     if 'app' not in request.fixturenames:
         return
 
-    app = request.getfuncargvalue('app')
+    app = getfixturevalue(request, 'app')
 
     # Get application bound to the live server if ``live_server`` fixture
     # is applyed. Live server application has an explicit ``SERVER_NAME``,
     # so ``url_for`` function generates a complete URL for endpoint which
     # includes application port as well.
     if 'live_server' in request.fixturenames:
-        app = request.getfuncargvalue('live_server').app
+        app = getfixturevalue(request, 'live_server').app
 
     ctx = app.test_request_context()
     ctx.push()
@@ -106,7 +107,7 @@ def _configure_application(request, monkeypatch):
     if 'app' not in request.fixturenames:
         return
 
-    app = request.getfuncargvalue('app')
+    app = getfixturevalue(request, 'app')
     options = request.keywords.get('options')
     if options is not None:
         for key, value in options.kwargs.items():

--- a/pytest_flask/pytest_compat.py
+++ b/pytest_flask/pytest_compat.py
@@ -2,4 +2,4 @@ def getfixturevalue(request, value):
     if hasattr(request, 'getfixturevalue'):
         return request.getfixturevalue(value)
 
-    return requesgit (value)
+    return request(value)

--- a/pytest_flask/pytest_compat.py
+++ b/pytest_flask/pytest_compat.py
@@ -2,4 +2,4 @@ def getfixturevalue(request, value):
     if hasattr(request, 'getfixturevalue'):
         return request.getfixturevalue(value)
 
-    return request(value)
+    return request.getfuncargvalue(value)

--- a/pytest_flask/pytest_compat.py
+++ b/pytest_flask/pytest_compat.py
@@ -1,0 +1,5 @@
+def getfixturevalue(request, value):
+    if hasattr(request, 'getfixturevalue'):
+        return request.getfixturevalue(value)
+
+    return requesgit (value)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,3 @@ mock
 pylint
 pytest-cov
 pytest-pep8
-pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{36,35,34,33,27,26}-pytest{30,29,28,27,26}
-    pypy-pytest{30,29,28,27,26}
+    py{36,35}-pytest{31,30,29,28,27}
+    py{34,33,27,26}-pytest{31,30,29,28,27,26}
+    pypy-pytest{31,30,29,28,27,26}
 
 
 [pytest]
@@ -16,10 +17,14 @@ usedevelop = True
 deps =
     -rrequirements/main.txt
     -rrequirements/test.txt
-    pytest23: pytest>=2.3,<2.4
-    pytest24: pytest>=2.4,<2.5
-    pytest25: pytest>=2.5,<2.6
     pytest26: pytest>=2.6,<2.7
+    pytest27: pytest>=2.7,<2.8
+    pytest28: pytest>=2.8,<2.9
+    pytest29: pytest>=2.9,<3.0
+    pytest30: pytest>=3.0,<3.1
+    pytest31: pytest>=3.1,<3.2
+    pytest26: pytest-xdist<1.16.0
+    pytest{31,30,29,28,27}: pytest-xdist
 
 passenv = HOME LANG LC_ALL
 
@@ -46,9 +51,9 @@ whitelist_externals =
 
 
 [tox:travis]
-2.6 = py26-pytest{30,29,28,27,26}
-2.7 = py27-pytest{30,29,28,27,26}
-3.3 = py33-pytest{30,29,28,27,26}
-3.4 = py34-pytest{30,29,28,27,26}
-3.5 = py35-pytest{30,29,28,27,26}
-3.6 = py36-pytest{30,29,28,27,26}
+2.6 = py26-pytest{31,30,29,28,27,26}
+2.7 = py27-pytest{31,30,29,28,27,26}
+3.3 = py33-pytest{31,30,29,28,27,26}
+3.4 = py34-pytest{31,30,29,28,27,26}
+3.5 = py35-pytest{31,30,29,28,27}
+3.6 = py36-pytest{31,30,29,28,27}


### PR DESCRIPTION
Howdy!

Here you have a patch for deprecated getfuncargvalue method. This PR is based on pytest-dev/pytest-django#393.

Cheers!