### PR TITLE
Fixes #96: `options` marker not registered

### DIFF
--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -171,3 +171,4 @@ def pytest_configure(config):
     config.addinivalue_line(
         'markers',
         'app(options): pass options to your application factory')
+    config.addinivalue_line('markers', 'options: app config manipulation')


### PR DESCRIPTION
This causes warning with pytest 4.5