### PR TITLE
Merge pull request #105 from mekza/fix_werkzeug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["2.7", "3.5", "3.6", "3.7", "3.8"]
+        tox_env: [
+          "py27",
+          "py35",
+          "py36",
+          "py37",
+          "py38",
+          "pre",
+        ]
+
+        include:
+          - tox_env: "py27"
+            python: "2.7"
+          - tox_env: "py35"
+            python: "3.5"
+          - tox_env: "py36"
+            python: "3.6"
+          - tox_env: "py37"
+            python: "3.7"
+          - tox_env: "py38"
+            python: "3.8"
+          - tox_env: "pre"
+            python: "3.7"
         
     steps:
     - uses: actions/checkout@v1
@@ -24,7 +45,7 @@ jobs:
         pip install tox
     - name: Test
       run: |
-        tox -e py
+        tox -e ${{ matrix.tox_env }}
   
   deploy:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+0.15.1 (2020-02-03)
+-------------------
+
+- Fix ``ImportError`` with ``Werkzeug 1.0.0rc1`` (`#105`_).
+
+.. _#105: https://github.com/pytest-dev/pytest-flask/pull/105
+
 0.15.0 (2019-05-13)
 -------------------
 

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 from flask import json
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 
 from .fixtures import (
     client, config, accept_json, accept_jsonp, accept_any, accept_mimetype,

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ norecursedirs = .git .tox env coverage docs
 pep8ignore =
     docs/conf.py ALL
 pep8maxlinelength = 119
+junit_family=xunit2
 
 
 [testenv]
@@ -28,6 +29,11 @@ commands =
         -ra \
         {posargs:tests}
 
+[testenv:pre]
+pip_pre=true
+usedevelop = {[testenv]usedevelop}
+deps = {[testenv]deps}
+commands = {[testenv]commands}
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Werkzeug 1.x changed things, raising an `ImportError`

```
ImportError: cannot import name 'cached_property' from 'werkzeug' 
```

Fix #106