### PR TITLE
Add a simple flask app factory and explanation to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,18 +3,36 @@ pytest-flask
 
 |PyPI version| |conda-forge version| |Python versions| |ci| |Documentation status|
 
-An extension of `pytest <http://pytest.org/>`__ test runner which
+An extension of `pytest`_ test runner which
 provides a set of useful tools to simplify testing and development
 of the Flask extensions and applications.
 
 To view a more detailed list of extension features and examples go to
-the `PyPI <https://pypi.python.org/pypi/pytest-flask>`__ overview page or
-`package documentation <http://pytest-flask.readthedocs.org/en/latest/>`_.
+the `PyPI`_ overview page or
+`package documentation`_.
 
 How to start?
 -------------
 
-Define your application fixture in ``conftest.py``:
+Considering the minimal flask `application factory`_ bellow in ``myapp.py`` as an example:
+
+.. code-block:: python
+
+   from flask import Flask
+
+   def create_app(config_filename):
+      # create a minimal app
+      app = Flask(__name__)
+      app.config.from_pyfile(config_filename)
+
+      # simple hello world view
+      @app.route('/hello')
+      def hello():
+         return 'Hello, World!'
+
+      return app
+
+You first need to define your application fixture in ``conftest.py``:
 
 .. code-block:: python
 
@@ -25,7 +43,7 @@ Define your application fixture in ``conftest.py``:
         app = create_app()
         return app
 
-Install the extension with dependencies and go::
+Finally, install the extension with dependencies and run your test suite::
 
     $ pip install pytest-flask
     $ pytest
@@ -33,7 +51,7 @@ Install the extension with dependencies and go::
 Contributing
 ------------
 
-Don’t hesitate to create a `GitHub issue <https://github.com/vitalk/pytest-flask/issues>`__ for any bug or
+Don’t hesitate to create a `GitHub issue`_ for any bug or
 suggestion.
 
 .. |PyPI version| image:: https://img.shields.io/pypi/v/pytest-flask.svg
@@ -55,3 +73,9 @@ suggestion.
 .. |Documentation status| image:: https://readthedocs.org/projects/pytest-flask/badge/?version=latest
    :target: https://pytest-flask.readthedocs.org/en/latest/
    :alt: Documentation status
+
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _PyPI: https://pypi.python.org/pypi/pytest-flask
+.. _Github issue: https://github.com/vitalk/pytest-flask/issues
+.. _package documentation: http://pytest-flask.readthedocs.org/en/latest/
+.. _application factory: https://flask.palletsprojects.com/en/1.1.x/patterns/appfactories/


### PR DESCRIPTION
This adds some details concerning the `create_app` function following the discussion on #99