### PR TITLE
Release 1.1.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@
 Changelog
 =========
 
-1.1.0 (UNRELEASED)
+1.1.0 (2020-11-08)
 ------------------
 
 - Speedup live server start time. Use `socket` instead of server


### PR DESCRIPTION
Our 1.1.0 release 🎉 

PR #58 is an impactful change for users and it has been a while since our last release so I believe now would be a good time for a new one.

**changes**

- Speedup live server start time. Use socket instead of server pulling (#58) to check server availability and add new --live-server-wait option to set the live server wait timeout