### PR TITLE
Use `pytest.fixture` rather than deprecated `yield_fixture`

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -30,7 +30,7 @@ def deprecated(reason):
     return decorator
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client(app):
     """A Flask test client. An instance of :class:`flask.testing.TestClient`
     by default.


### PR DESCRIPTION
Just took this project for a spin for the first time and noticed this while reading the code.

Quoting https://docs.pytest.org/en/stable/yieldfixture.html:
> Since pytest-3.0, fixtures using the normal fixture decorator can use a yield statement to provide fixture values and execute teardown code, exactly like yield_fixture in previous versions.
>
> Marking functions as yield_fixture is still supported, but deprecated and should not be used in new code.

Hope this helps, and thanks for maintaining pytest-flask!
