### PR TITLE
Release 1.2.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,12 +3,14 @@
 Changelog
 =========
 
-1.2.0 (UNRELEASED)
+1.2.0 (2021-02-26)
 ------------------
 
 - Remove deprecated ``:meth:live_server.url``
 - fixture ``request_ctx is now deprecated``
   and will be removed in the future
+- ``JSONReponse.json`` removed in favour of
+  ``Werkzeug.wrappers.Response.json``
 
 1.1.0 (2020-11-08)
 ------------------


### PR DESCRIPTION
Our new 1.2.0 release 🎉 

Changes

- Remove deprecated ``:meth:live_server.url``

- Fixture ``request_ctx is now deprecated``
  and will be removed in the future

- `JSONReponse.json` removed in favour of 
  `Werkzeug.wrappers.Response.json`

Along with some internal changes for better separation of concerns (new `_internal.py` and `live_server.py` modules) and extension of test suite coverage to 100%

