### PR TITLE
Force multiprocessing fork on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,42 +1,33 @@
 name: build
 
 on: [push, pull_request]
-
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        tox_env: [
-          "py35",
-          "py36",
-          "py37",
-          "py38",
-          "pre",
-          "linting",
-        ]
-
+        python: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        os: [ubuntu-latest, macos-latest]
         include:
-          - tox_env: "py35"
-            python: "3.5"
-          - tox_env: "py36"
-            python: "3.6"
-          - tox_env: "py37"
-            python: "3.7"
-          - tox_env: "py38"
-            python: "3.8"
-          - tox_env: "pre"
-            python: "3.7"
-          - tox_env: "linting"
-            python: "3.7"
-
+          - python: "3.5"
+            tox_env: "py35"
+          - python: "3.6"
+            tox_env: "py36"
+          - python: "3.7"
+            tox_env: "py37"
+          - python: "3.8"
+            tox_env: "py38"
+          - python: "3.9"
+            tox_env: "py39"
+          - python: "3.8"
+            tox_env: "pre"
+          - python: "3.8"
+            tox_env: "linting"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox
@@ -46,21 +37,16 @@ jobs:
     - name: Test
       run: |
         tox -e ${{ matrix.tox_env }}
-
   deploy:
-
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-
     runs-on: ubuntu-latest
-
     needs: build
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: "3.7"
+        python-version: "3.8"
     - name: Install wheel
       run: |
         python -m pip install --upgrade pip

--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -8,7 +8,6 @@ from flask import _request_ctx_stack
 from ._internal import _determine_scope
 from ._internal import _make_accept_header
 from ._internal import _rewrite_server_name
-from ._internal import deprecated
 from .live_server import LiveServer
 
 

--- a/pytest_flask/live_server.py
+++ b/pytest_flask/live_server.py
@@ -9,6 +9,11 @@ import time
 import pytest
 
 
+# force 'fork' on macOS
+if platform.system() == "Darwin":
+    multiprocessing.set_start_method("fork")
+
+
 class LiveServer:
     """The helper class used to manage a live server. Handles creation and
     stopping application in a separate process.
@@ -27,10 +32,6 @@ class LiveServer:
         self.wait = wait
         self.clean_stop = clean_stop
         self._process = None
-
-        # force fork on macOS
-        if platform.system() == "Darwin":
-            multiprocessing.set_start_method("fork")
 
     def start(self):
         """Start application in a separate process."""

--- a/pytest_flask/live_server.py
+++ b/pytest_flask/live_server.py
@@ -8,8 +8,6 @@ import time
 
 import pytest
 
-from ._internal import deprecated
-
 
 class LiveServer:
     """The helper class used to manage a live server. Handles creation and

--- a/pytest_flask/live_server.py
+++ b/pytest_flask/live_server.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import os
+import platform
 import signal
 import socket
 import time
@@ -28,6 +29,10 @@ class LiveServer:
         self.wait = wait
         self.clean_stop = clean_stop
         self._process = None
+
+        # force fork on macOS
+        if platform.system() == "Darwin":
+            multiprocessing.set_start_method("fork")
 
     def start(self):
         """Start application in a separate process."""

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -5,11 +5,7 @@
     :copyright: (c) by Vital Kudzelka
     :license: MIT
 """
-import sys
-
 import pytest
-from flask import json
-from werkzeug.utils import cached_property
 
 from .fixtures import accept_any
 from .fixtures import accept_json

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 

--- a/tests/test_json_response.py
+++ b/tests/test_json_response.py
@@ -1,5 +1,4 @@
 import pytest
-from flask import Flask
 from flask import url_for
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
-    py{35,36,37,38,linting}
+    py{35,36,37,38,39,linting}
 
 [pytest]
 norecursedirs = .git .tox env coverage docs
 pep8ignore =
     docs/conf.py ALL
-pep8maxlinelength = 119
+pep8maxlinelength = 79
 
 [testenv:dev]
 commands =
@@ -17,7 +17,7 @@ deps=
     -rrequirements/docs.txt
     pre-commit>=1.11.0
     tox
-basepython = python3.7
+basepython = python3.8
 usedevelop = True
 
 [testenv]
@@ -54,7 +54,7 @@ commands = {[testenv]commands}
 
 [testenv:linting]
 skip_install = True
-basepython = python3.7
+basepython = python3.8
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
 


### PR DESCRIPTION
I came across this problem when running some tests with pytest-flask on an unrelated application: From [multiprocessing docs ](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), "On macOS, the spawn start method is now the default". This causes `LiveServer` to throw a pickling error on `py39` and totally break. I propose we stick to "fork" method for now until a proper fix  in `LiveServer` (I'll open a follow up issue on this).

- [x] force "fork" to start processes in macOS
- [x] add macOS to test matrix
- [x] add py39 to test matrix
- [x] remove unused imports