### PR TITLE
re-add missing url method to live_server

### DIFF
--- a/pytest_flask/live_server.py
+++ b/pytest_flask/live_server.py
@@ -69,6 +69,12 @@ class LiveServer:
             sock.close()
         return ret
 
+    def url(self, url=""):
+        """Returns the complete url based on server options."""
+        return "http://{host!s}:{port!s}{url!s}".format(
+            host=self.host, port=self.port, url=url
+        )
+
     def stop(self):
         """Stop application process."""
         if self._process:

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -12,6 +12,7 @@ class TestLiveServer:
     def test_init(self, live_server):
         assert live_server.port
         assert live_server.host == "localhost"
+        assert live_server.url() == "http://localhost:{0}".format(live_server.port)
 
     def test_server_is_alive(self, live_server):
         assert live_server._process


### PR DESCRIPTION
Fixes #140. This is a literal copy-paste of the method as it existed prior to v1.2.0 (prior to e9b8321b3e1051b163ad5342db0aa529e5f7ce9f)