### PR TITLE
change server_name default to localhost.localdomain (#149)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+1.2.1
+------------------
+- Fix bug in ``:meth:pytest_flask.fixtures.live_server``
+  where ``SESSION_COOKIE_DOMAIN`` was set to false due to
+  ``original_server_name`` defaulting to "localhost".
+  The new default is "localhost.localdomain".
+
 1.2.0 (2021-02-26)
 ------------------
 

--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -69,7 +69,7 @@ def live_server(request, app, pytestconfig):
     host = pytestconfig.getvalue("live_server_host")
 
     # Explicitly set application ``SERVER_NAME`` for test suite
-    original_server_name = app.config["SERVER_NAME"] or "localhost"
+    original_server_name = app.config["SERVER_NAME"] or "localhost.localdomain"
     final_server_name = _rewrite_server_name(original_server_name, str(port))
     app.config["SERVER_NAME"] = final_server_name
 


### PR DESCRIPTION
Change the default server_name of the live_server fixture to "localhost.localdomain" to address potential issues when setting cookies on the client.


fixes #149
