### PR TITLE
drop python 3.5 and 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        python: [3.7", "3.8", "3.9"]
         os: [ubuntu-latest, macos-latest]
         include:
-          - python: "3.5"
-            tox_env: "py35"
-          - python: "3.6"
-            tox_env: "py36"
           - python: "3.7"
             tox_env: "py37"
           - python: "3.8"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
   where ``SESSION_COOKIE_DOMAIN`` was set to false due to
   ``original_server_name`` defaulting to "localhost".
   The new default is "localhost.localdomain".
+- Drop support for python 3.6 and 3.5
 
 1.2.0 (2021-02-26)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers=
 [options]
 packages = find:
 zip_safe = False
-python_requires = >= 3.5
+python_requires = >= 3.7
 setup_requires = setuptools_scm
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,6 @@ classifiers=
     Environment :: Web Environment
     Intended Audience :: Developers
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39,linting}
+    py{37,38,39,linting}
 
 [pytest]
 norecursedirs = .git .tox env coverage docs


### PR DESCRIPTION
- [x] drop py35 and py36

https://peps.python.org/pep-0494/#lifespan