### PR TITLE
README: remove unset excessive `config_filename` in "How to start?"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,9 @@ Considering the minimal flask `application factory`_ below in ``myapp.py`` as an
 
    from flask import Flask
 
-   def create_app(config_filename):
+   def create_app():
       # create a minimal app
       app = Flask(__name__)
-      app.config.from_pyfile(config_filename)
 
       # simple hello world view
       @app.route('/hello')


### PR DESCRIPTION
`config_filename` is left in the app factory definition but it is not provided in the fixture in both this section and "Getting started" (in "docs")

<!--
Before opening a pull request, please open an issue describing the problem or feature the pull request will adress. You can follow the steps in CONTRIBUTING.rst. in case of any doubts regarding the process.

Replace this comment with a description of the change.
-->

<!--
Link to relevant issue(s). Use "fixes" to automatically close an issue.
-->

- fixes #154 

<!--
Make sure to complete each step bellow and add "x" to each box.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
