### PR TITLE
darwin: Correctly use fork for multiprocessing

### DIFF
--- a/pytest_flask/live_server.py
+++ b/pytest_flask/live_server.py
@@ -11,7 +11,7 @@ import pytest
 
 # force 'fork' on macOS
 if platform.system() == "Darwin":
-    multiprocessing.set_start_method("fork")
+    multiprocessing = multiprocessing.get_context("fork")
 
 
 class LiveServer:


### PR DESCRIPTION
Fix according to: https://github.com/pytest-dev/pytest-flask/issues/139#issuecomment-963916698