### PR TITLE
Remove `request_ctx` Fixture

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -188,28 +188,6 @@ in your project's ``pytest.ini`` file)::
     addopts = --live-server-port=5000
 
 
-``request_ctx`` - request context (Deprecated)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**This fixture is deprecated and will be removed in the future.**
-
-The request context which contains all request relevant information.
-
-.. hint::
-
-    The request context has been pushed implicitly any time the ``app``
-    fixture is applied and is kept around during test execution, so it’s easy
-    to introspect the data:
-
-    .. code:: python
-
-        from flask import request, url_for
-
-        def test_request_headers(client):
-            res = client.get(url_for('ping'), headers=[('X-Something', '42')])
-            assert request.headers['X-Something'] == '42'
-
-
 ``live_server_scope`` - set the scope of the live server
 ``````````````````````````````````````````````````````````````````
 

--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -3,7 +3,6 @@ import socket
 import warnings
 
 import pytest
-from flask import _request_ctx_stack
 
 from ._internal import _determine_scope
 from ._internal import _make_accept_header
@@ -90,23 +89,6 @@ def live_server(request, app, pytestconfig):
 def config(app):
     """An application config."""
     return app.config
-
-
-@pytest.fixture
-def request_ctx(app):
-    """The request context which contains all request relevant information,
-    e.g. `session`, `g`, `flashes`, etc.
-    """
-    warnings.warn(
-        "In Werzeug 2.0.0, the Client request methods "
-        "(client.get, client.post) always return an instance of TestResponse. This "
-        "class provides a reference to the request object through 'response.request' "
-        "The fixture 'request_ctx' is deprecated and will be removed in the future, using TestResponse.request "
-        "is the preferred way.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _request_ctx_stack.top
 
 
 @pytest.fixture(params=["application/json", "text/html"])

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -15,7 +15,6 @@ from .fixtures import client
 from .fixtures import client_class
 from .fixtures import config
 from .fixtures import live_server
-from .fixtures import request_ctx
 from .pytest_compat import getfixturevalue
 
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -16,21 +16,6 @@ class TestFixtures:
     def test_accept_jsonp(self, accept_jsonp):
         assert accept_jsonp == [("Accept", "application/json-p")]
 
-    def test_request_ctx(self, app, request_ctx):
-        assert request_ctx.app is app
-
-    def test_request_ctx_is_kept_around(self, client):
-        res = client.get(url_for("index"), headers=[("X-Something", "42")])
-        """In werkzeug 2.0.0 the test Client provides a new attribute 'request'
-        in the response class which holds a reference to the request object that
-        produced the respective response, making instrospection easier"""
-        try:
-            assert res.request.headers["X-Something"] == "42"
-        except AttributeError:
-            """This is the conventional (pre 2.0.0) way of reaching the
-            request object, using flask.request global."""
-            assert request.headers["X-Something"] == "42"
-
     def test_accept_mimetype(self, accept_mimetype):
         mimestrings = [[("Accept", "application/json")], [("Accept", "text/html")]]
         assert accept_mimetype in mimestrings


### PR DESCRIPTION
This pull request removed the `request_ctx` fixture since it has been marked deprecated for a long time and currently it is not supported on the Flask v3.0.0.

For a side note, inlining the import won't work since it could still break the test if using Flask v3.0.0.

- Fixes #167.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
