### PR TITLE
Add mypy to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ src/pytest_flask/_version.py
 # Editors
 .vscode
 .code-workspace
+.python-version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,9 @@ Changelog
 UNRELEASED
 ----------
 
-* Added support for Python 3.10, 3.11, and 3.12.
-* Dropped support for EOL Python 3.7.
+* Add support for Python 3.10, 3.11, and 3.12.
+* Drop support for EOL Python 3.7.
+* Add type hints.
 
 1.3.0 (2023-10-23)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,12 @@ requires = [
   "setuptools-scm[toml]",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+enable_error_code = [
+    "ignore-without-code",
+    "truthy-bool",
+]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ mock
 pylint
 coverage
 pytest-pep8
+mypy

--- a/src/pytest_flask/_internal.py
+++ b/src/pytest_flask/_internal.py
@@ -1,7 +1,7 @@
 import functools
+import warnings
 from typing import Callable
 from typing import Literal
-import warnings
 
 from pytest import Config as _PytestConfig
 

--- a/src/pytest_flask/_internal.py
+++ b/src/pytest_flask/_internal.py
@@ -1,8 +1,15 @@
 import functools
+from typing import Callable
+from typing import Literal
 import warnings
 
+from pytest import Config as _PytestConfig
 
-def deprecated(reason):
+
+_PytestScopeName = Literal["session", "package", "module", "class", "function"]
+
+
+def deprecated(reason: str) -> Callable:
     """Decorator which can be used to mark function or method as deprecated.
     It will result a warning being emitted when the function is called."""
 
@@ -19,7 +26,7 @@ def deprecated(reason):
     return decorator
 
 
-def _rewrite_server_name(server_name, new_port):
+def _rewrite_server_name(server_name: str, new_port: str) -> str:
     """Rewrite server port in ``server_name`` with ``new_port`` value."""
     sep = ":"
     if sep in server_name:
@@ -27,7 +34,7 @@ def _rewrite_server_name(server_name, new_port):
     return sep.join((server_name, new_port))
 
 
-def _determine_scope(*, fixture_name, config):
+def _determine_scope(*, fixture_name: str, config: _PytestConfig) -> _PytestScopeName:
     return config.getini("live_server_scope")
 
 

--- a/src/pytest_flask/fixtures.py
+++ b/src/pytest_flask/fixtures.py
@@ -4,12 +4,12 @@ from typing import Any
 from typing import cast
 from typing import Generator
 
+import pytest
 from flask import Flask as _FlaskApp
 from flask.config import Config as _FlaskAppConfig
 from flask.testing import FlaskClient as _FlaskTestClient
 from pytest import Config as _PytestConfig
 from pytest import FixtureRequest as _PytestFixtureRequest
-import pytest
 
 from ._internal import _determine_scope
 from ._internal import _make_accept_header

--- a/src/pytest_flask/live_server.py
+++ b/src/pytest_flask/live_server.py
@@ -28,7 +28,7 @@ class _SupportsFlaskAppRun(Protocol):
 
 # force 'fork' on macOS
 if platform.system() == "Darwin":
-    multiprocessing = multiprocessing.get_context("fork")  # type: ignore
+    multiprocessing = multiprocessing.get_context("fork")  # type: ignore[assignment]
 
 
 class LiveServer:  # pragma: no cover

--- a/src/pytest_flask/live_server.py
+++ b/src/pytest_flask/live_server.py
@@ -63,11 +63,8 @@ class LiveServer:  # pragma: no cover
         def worker(app: _SupportsFlaskAppRun, host: str, port: int) -> None:
             app.run(host=host, port=port, use_reloader=False, threaded=True)
 
-        self._process = cast(
-            Process,
-            multiprocessing.Process(
-                target=worker, args=(self.app, self.host, self.port)
-            ),
+        self._process = multiprocessing.Process(
+            target=worker, args=(self.app, self.host, self.port)
         )
         self._process.daemon = True
         self._process.start()

--- a/src/pytest_flask/live_server.py
+++ b/src/pytest_flask/live_server.py
@@ -1,11 +1,11 @@
 import logging
 import multiprocessing
-from multiprocessing import Process
 import os
 import platform
 import signal
 import socket
 import time
+from multiprocessing import Process
 from typing import Any
 from typing import cast
 from typing import Protocol
@@ -17,9 +17,9 @@ import pytest
 class _SupportsFlaskAppRun(Protocol):
     def run(
         self,
-        host: str | None = None,
-        port: int | None = None,
-        debug: bool | None = None,
+        host: Union[str, None] = None,
+        port: Union[int, None] = None,
+        debug: Union[bool, None] = None,
         load_dotenv: bool = True,
         **options: Any,
     ) -> None:

--- a/src/pytest_flask/live_server.py
+++ b/src/pytest_flask/live_server.py
@@ -1,17 +1,34 @@
 import logging
 import multiprocessing
+from multiprocessing import Process
 import os
 import platform
 import signal
 import socket
 import time
+from typing import Any
+from typing import cast
+from typing import Protocol
+from typing import Union
 
 import pytest
 
 
+class _SupportsFlaskAppRun(Protocol):
+    def run(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        debug: bool | None = None,
+        load_dotenv: bool = True,
+        **options: Any,
+    ) -> None:
+        ...
+
+
 # force 'fork' on macOS
 if platform.system() == "Darwin":
-    multiprocessing = multiprocessing.get_context("fork")
+    multiprocessing = multiprocessing.get_context("fork")  # type: ignore
 
 
 class LiveServer:  # pragma: no cover
@@ -25,27 +42,37 @@ class LiveServer:  # pragma: no cover
                  application is not started.
     """
 
-    def __init__(self, app, host, port, wait, clean_stop=False):
+    def __init__(
+        self,
+        app: _SupportsFlaskAppRun,
+        host: str,
+        port: int,
+        wait: int,
+        clean_stop: bool = False,
+    ):
         self.app = app
         self.port = port
         self.host = host
         self.wait = wait
         self.clean_stop = clean_stop
-        self._process = None
+        self._process: Union[Process, None] = None
 
-    def start(self):
+    def start(self) -> None:
         """Start application in a separate process."""
 
-        def worker(app, host, port):
+        def worker(app: _SupportsFlaskAppRun, host: str, port: int) -> None:
             app.run(host=host, port=port, use_reloader=False, threaded=True)
 
-        self._process = multiprocessing.Process(
-            target=worker, args=(self.app, self.host, self.port)
+        self._process = cast(
+            Process,
+            multiprocessing.Process(
+                target=worker, args=(self.app, self.host, self.port)
+            ),
         )
         self._process.daemon = True
         self._process.start()
 
-        keep_trying = True
+        keep_trying: bool = True
         start_time = time.time()
         while keep_trying:
             elapsed_time = time.time() - start_time
@@ -57,7 +84,7 @@ class LiveServer:  # pragma: no cover
             if self._is_ready():
                 keep_trying = False
 
-    def _is_ready(self):
+    def _is_ready(self) -> bool:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((self.host, self.port))
@@ -69,13 +96,13 @@ class LiveServer:  # pragma: no cover
             sock.close()
         return ret
 
-    def url(self, url=""):
+    def url(self, url: str = "") -> str:
         """Returns the complete url based on server options."""
         return "http://{host!s}:{port!s}{url!s}".format(
             host=self.host, port=self.port, url=url
         )
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop application process."""
         if self._process:
             if self.clean_stop and self._stop_cleanly():
@@ -84,14 +111,17 @@ class LiveServer:  # pragma: no cover
                 # If it's still alive, kill it
                 self._process.terminate()
 
-    def _stop_cleanly(self, timeout=5):
+    def _stop_cleanly(self, timeout: int = 5) -> bool:
         """Attempts to stop the server cleanly by sending a SIGINT
         signal and waiting for ``timeout`` seconds.
 
         :return: True if the server was cleanly stopped, False otherwise.
         """
+        if not self._process:
+            return True
+
         try:
-            os.kill(self._process.pid, signal.SIGINT)
+            os.kill(cast(int, self._process.pid), signal.SIGINT)
             self._process.join(timeout)
             return True
         except Exception as ex:

--- a/src/pytest_flask/plugin.py
+++ b/src/pytest_flask/plugin.py
@@ -6,12 +6,14 @@
     :license: MIT
 """
 from typing import Any
+from typing import List
 from typing import Protocol
 from typing import Type
 from typing import TypeVar
+from typing import Union
 
-from _pytest.config import Config as _PytestConfig
 import pytest
+from _pytest.config import Config as _PytestConfig
 
 from .fixtures import accept_any
 from .fixtures import accept_json
@@ -53,7 +55,7 @@ class JSONResponse:
 
 def pytest_assertrepr_compare(
     op: str, left: _SupportsPytestFlaskEqual, right: int
-) -> list[str] | None:
+) -> Union[List[str], None]:
     if isinstance(left, JSONResponse) and op == "==" and isinstance(right, int):
         return [
             "Mismatch in status code for response: {} != {}".format(

--- a/src/pytest_flask/plugin.py
+++ b/src/pytest_flask/plugin.py
@@ -60,7 +60,7 @@ def pytest_assertrepr_compare(
                 left.status_code,
                 right,
             ),
-            f"Response status: {left.status}",
+            f"Response status: {left.status_code}",
         ]
     return None
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,linting}
+    py{37,38,39,linting},mypy
 
 [pytest]
 norecursedirs = .git .tox env coverage docs
@@ -16,6 +16,7 @@ deps=
     -rrequirements/test.txt
     -rrequirements/docs.txt
     pre-commit>=1.11.0
+    mypy>=1.6.1
     tox
 basepython = python3.8
 usedevelop = True
@@ -55,6 +56,11 @@ skip_install = True
 basepython = python3.8
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
+
+[testenv:mypy]
+basepython = python3.8
+deps = mypy>=1.6.1
+commands = mypy src
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,linting},mypy
+    py{38,39,310,311,312,linting},mypy
 
 [pytest]
 norecursedirs = .git .tox env coverage docs


### PR DESCRIPTION
PR provides some type hints (as per #176) and adjusts GitHub CI to respect them.

- Add type hints to code base
- New environment to check type hints was added to `tox`
- `tox` configuration was updated to keep python envs consistent with GitHub CI (py37 was dropped, py311 and py312 were added)

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/CHANGELOG.rst`, summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
