### PR TITLE
Use pre commit to run mypy #176

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
     rev: v2.2.1
     hooks:
     -   id: autoflake
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+    -   id: mypy
+        files: ^(src/|tests/)

--- a/src/pytest_flask/fixtures.py
+++ b/src/pytest_flask/fixtures.py
@@ -45,7 +45,7 @@ def client_class(request: _PytestFixtureRequest, client: _FlaskTestClient) -> No
         request.cls.client = client
 
 
-@pytest.fixture(scope=_determine_scope)  # type: ignore[arg-type]
+@pytest.fixture(scope=_determine_scope)
 def live_server(
     request: _PytestFixtureRequest, app: _FlaskApp, pytestconfig: _PytestConfig
 ) -> Generator[LiveServer, Any, Any]:  # pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,linting},mypy
+    py{38,39,310,311,312,linting}
 
 [pytest]
 norecursedirs = .git .tox env coverage docs
@@ -56,11 +56,6 @@ skip_install = True
 basepython = python3.8
 deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure {posargs:}
-
-[testenv:mypy]
-basepython = python3.8
-deps = mypy>=1.6.1
-commands = mypy src
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Move the `mypy` run into the pre-commit hook instead of tox.

As @nicoddemus suggested move `mypy` run into pre-commit hook. This change automatically includes mypy check into the GitHub CI.