### PR TITLE
Update ref to maintenance badge in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ pytest-flask
    :target: https://pytest-flask.readthedocs.org/en/latest/
    :alt: Documentation status
 
-.. image:: https://img.shields.io/maintenance/yes/2022?color=blue
+.. image:: https://img.shields.io/maintenance/yes/2023?color=blue
     :target: https://github.com/pytest-dev/pytest-flask
     :alt: Maintenance
 


### PR DESCRIPTION
Update link to the maintenance badge to use current year instead of 2022