### PR TITLE
198: remove deprecated setuptools' tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,15 @@ from pathlib import Path
 
 from setuptools import setup
 
-tests_require = []
 requirements = Path("requirements/main.txt").read_text(encoding="UTF-8").splitlines()
 extras_require = {
     "docs": Path("requirements/docs.txt").read_text(encoding="UTF-8").splitlines(),
-    "tests": [tests_require],
+    "tests": [],
 }
 
 setup(
     # Dependencies are here for GitHub's dependency graph.
     use_scm_version={"write_to": "src/pytest_flask/_version.py"},
     install_requires=requirements,
-    tests_require=tests_require,
     extras_require=extras_require,
 )


### PR DESCRIPTION
Remove setuptools' tests_require deprecated method.
fixes [198](https://github.com/pytest-dev/pytest-flask/issues/198).
<!--
Before opening a pull request, please open an issue describing the problem or feature the pull request will adress. You can follow the steps in CONTRIBUTING.rst. in case of any doubts regarding the process.

Replace this comment with a description of the change.
-->

<!--
Link to relevant issue(s). Use "fixes" to automatically close an issue.
-->

- fixes #<issue number>

<!--
Make sure to complete each step bellow and add "x" to each box.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/CHANGELOG.rst`, summarizing the change and linking to the issue.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and make sure  no tests failed.
