### PR TITLE
fix: remove deprecated tests_require from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,14 @@ from pathlib import Path
 
 from setuptools import setup
 
-tests_require = []
 requirements = Path("requirements/main.txt").read_text(encoding="UTF-8").splitlines()
 extras_require = {
     "docs": Path("requirements/docs.txt").read_text(encoding="UTF-8").splitlines(),
-    "tests": [tests_require],
 }
 
 setup(
     # Dependencies are here for GitHub's dependency graph.
     use_scm_version={"write_to": "src/pytest_flask/_version.py"},
     install_requires=requirements,
-    tests_require=tests_require,
     extras_require=extras_require,
 )


### PR DESCRIPTION
Fixed the bug described in issue #198. The `tests_require` parameter in setuptools has been deprecated and removed — it now produces a warning when running `pip install -v .`. Since `tests_require` was already an empty list anyway, this fix removes it entirely from setup.py along with its reference in `extras_require`. This eliminates the deprecation warning without any functional change.